### PR TITLE
deprecated BatchNorm2d

### DIFF
--- a/model/tools/module_helper.py
+++ b/model/tools/module_helper.py
@@ -25,9 +25,9 @@ class ModuleHelper(object):
                 nn.ReLU()
             )
         elif norm_type == 'encsync_batchnorm':
-            from encoding.nn import BatchNorm2d
+            from encoding.nn import SyncBatchNorm
             return nn.Sequential(
-                BatchNorm2d(num_features, **kwargs),
+                SyncBatchNorm(num_features, **kwargs),
                 nn.ReLU()
             )
         elif norm_type == 'instancenorm':


### PR DESCRIPTION
BatchNorm2d from torchencoding is deprecated in favor of SyncBatchNorm